### PR TITLE
Add `Mondrian.`

### DIFF
--- a/Demo_MondrianLayout/Book.Background.swift
+++ b/Demo_MondrianLayout/Book.Background.swift
@@ -7,7 +7,8 @@ var _book_background: BookView {
   BookNavigationLink(title: "Background") {
     BookPreview {
       ExampleView(width: nil, height: nil) { (view: UIView) in
-        view.mondrian.buildSubviews {
+
+        Mondrian.buildSubviews(on: view) {
           VStackBlock {
             UIView.mock(
               backgroundColor: .mondrianYellow,
@@ -25,12 +26,13 @@ var _book_background: BookView {
           .padding(10)
           .background(UIView.mock(backgroundColor: .mondrianGray))
         }
+
       }
     }
 
     BookPreview {
       ExampleView(width: nil, height: nil) { (view: UIView) in
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           VStackBlock(spacing: 2) {
             UIView.mock(
               backgroundColor: .mondrianYellow,
@@ -69,7 +71,7 @@ var _book_background: BookView {
 
     BookPreview {
       ExampleView(width: nil, height: nil) { (view: UIView) in
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           VStackBlock {
             UIView.mock(
               backgroundColor: .mondrianYellow,

--- a/Demo_MondrianLayout/Book.Classic.swift
+++ b/Demo_MondrianLayout/Book.Classic.swift
@@ -171,7 +171,7 @@ var _book_classic: BookView {
           let box1 = UIView.mock(backgroundColor: .neon(.red), preferredSize: .largeSquare)
           let box2 = UIView.mock(backgroundColor: .neon(.yellow), preferredSize: .largeSquare)
 
-          view.mondrian.buildSubviews {
+          Mondrian.buildSubviews(on: view) {
             HStackBlock(spacing: 10) {
               box1
               box2

--- a/Demo_MondrianLayout/Book.Classic.swift
+++ b/Demo_MondrianLayout/Book.Classic.swift
@@ -14,7 +14,7 @@ var _book_classic: BookView {
         view.addSubview(box1)
         view.addSubview(box2)
 
-        mondrianBatchLayout {
+        Mondrian.layout {
 
           box1.mondrian.layout
             .top(.toSuperview, .min(0))

--- a/Demo_MondrianLayout/Book.HStackBlock.swift
+++ b/Demo_MondrianLayout/Book.HStackBlock.swift
@@ -13,7 +13,7 @@ var _book_HStackBlock: BookView {
         alignment in
         BookPreview {
           ExampleView(width: 180, height: nil) { (view: UIView) in
-            view.mondrian.buildSubviews {
+            Mondrian.buildSubviews(on: view) {
               VStackBlock(alignment: alignment) {
 
                 HStackBlock(spacing: 4) {
@@ -50,7 +50,7 @@ var _book_HStackBlock: BookView {
         alignment in
         BookPreview {
           ExampleView(width: 60, height: nil) { (view: UIView) in
-            view.mondrian.buildSubviews {
+            Mondrian.buildSubviews(on: view) {
               VStackBlock(alignment: alignment) {
 
                 UIView.mock(
@@ -69,7 +69,7 @@ var _book_HStackBlock: BookView {
         alignment in
         BookPreview {
           ExampleView(width: 60, height: nil) { (view: UIView) in
-            view.mondrian.buildSubviews {
+            Mondrian.buildSubviews(on: view) {
               VStackBlock(alignment: alignment) {
 
                 StackingSpacer(minLength: 10)
@@ -87,7 +87,7 @@ var _book_HStackBlock: BookView {
 
       BookPreview {
         ExampleView(width: 180, height: nil) { (view: UIView) in
-          view.mondrian.buildSubviews {
+          Mondrian.buildSubviews(on: view) {
             VStackBlock {
               HStackBlock(spacing: 10) {
                 UIView.mock(
@@ -179,7 +179,7 @@ var _book_HStackBlock: BookView {
         alignment in
         BookPreview {
           ExampleView(width: nil, height: nil) { (view: UIView) in
-            view.mondrian.buildSubviews {
+            Mondrian.buildSubviews(on: view) {
               HStackBlock(spacing: 4, alignment: alignment) {
                 UILabel.mockMultiline(text: "Hello\nHello", textColor: .white)
                   .viewBlock
@@ -202,7 +202,7 @@ var _book_HStackBlock: BookView {
 
       BookPreview {
         ExampleView(width: nil, height: nil) { (view: UIView) in
-          view.mondrian.buildSubviews {
+          Mondrian.buildSubviews(on: view) {
             HStackBlock(spacing: 4) {
               UIView.mock(
                 backgroundColor: .mondrianYellow,
@@ -226,7 +226,7 @@ var _book_HStackBlock: BookView {
 
       BookPreview {
         ExampleView(width: nil, height: nil) { (view: UIView) in
-          view.mondrian.buildSubviews {
+          Mondrian.buildSubviews(on: view) {
             HStackBlock(spacing: 4) {
               UIView.mock(
                 backgroundColor: .mondrianYellow,

--- a/Demo_MondrianLayout/Book.Mondrian.swift
+++ b/Demo_MondrianLayout/Book.Mondrian.swift
@@ -6,7 +6,7 @@ import UIKit
 var _book_mondrian: BookView {
   BookPreview {
     ExampleView(width: 200, height: 200) { (view: UIView) in
-      view.mondrian.buildSubviews {
+      Mondrian.buildSubviews(on: view) {
 
         HStackBlock(spacing: 2, alignment: .fill) {
           VStackBlock(spacing: 2, alignment: .fill) {
@@ -137,7 +137,7 @@ var _book_mondrian: BookView {
 var _book_neonGrid: BookView {
   BookPreview {
     ExampleView(width: nil, height: nil) { (view: UIView) in
-      view.mondrian.buildSubviews {
+      Mondrian.buildSubviews(on: view) {
 
         VStackBlock(spacing: 2, alignment: .fill) {
 

--- a/Demo_MondrianLayout/Book.Overlay.swift
+++ b/Demo_MondrianLayout/Book.Overlay.swift
@@ -8,7 +8,7 @@ var _book_overlay: BookView {
     BookPreview {
       ExampleView(width: nil, height: nil) { (view: UIView) in
 
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           UIView.mock(
             backgroundColor: .mondrianYellow,
             preferredSize: .init(width: 100, height: 100)
@@ -31,7 +31,7 @@ var _book_overlay: BookView {
 
     BookPreview {
       ExampleView(width: nil, height: nil) { (view: UIView) in
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           UIView.mock(
             backgroundColor: .mondrianYellow,
             preferredSize: .init(width: 100, height: 100)
@@ -53,7 +53,7 @@ var _book_overlay: BookView {
 
     BookPreview {
       ExampleView(width: nil, height: nil) { (view: UIView) in
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           VStackBlock {
             UIView.mock(
               backgroundColor: .mondrianYellow,
@@ -76,7 +76,7 @@ var _book_overlay: BookView {
 
     BookPreview {
       ExampleView(width: nil, height: nil) { (view: UIView) in
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           VStackBlock(spacing: 2) {
             UIView.mock(
               backgroundColor: .mondrianYellow,
@@ -115,7 +115,7 @@ var _book_overlay: BookView {
 
     BookPreview {
       ExampleView(width: nil, height: nil) { (view: UIView) in
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           VStackBlock {
             UIView.mock(
               backgroundColor: .mondrianYellow,

--- a/Demo_MondrianLayout/Book.RelativeBlock.swift
+++ b/Demo_MondrianLayout/Book.RelativeBlock.swift
@@ -14,7 +14,7 @@ var _book_RelativeBlock: BookView {
 
     BookPreview {
       ExampleView(width: 100, height: 100) { view in
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           LayoutContainer(attachedSafeAreaEdges: .all) {
             ZStackBlock {
 
@@ -33,7 +33,7 @@ var _book_RelativeBlock: BookView {
 
     BookPreview {
       ExampleView(width: 100, height: 100) { view in
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           ZStackBlock {
             UILabel.mockSingleline(text: "A")
               .viewBlock
@@ -47,7 +47,7 @@ var _book_RelativeBlock: BookView {
 
     BookPreview {
       ExampleView(width: 100, height: 100) { view in
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           ZStackBlock {
             ZStackBlock {
               UILabel.mockSingleline(text: "Hello Hello Hello")
@@ -63,7 +63,7 @@ var _book_RelativeBlock: BookView {
 
     BookPreview {
       ExampleView(width: 100, height: 100) { view in
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           ZStackBlock {
             ZStackBlock {
               UILabel.mockSingleline(text: "Hello Hello Hello")
@@ -77,7 +77,7 @@ var _book_RelativeBlock: BookView {
 
     BookPreview {
       ExampleView(width: nil, height: nil) { (view: UIView) in
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           VStackBlock {
             ZStackBlock {
               UIView.mock(

--- a/Demo_MondrianLayout/Book.SafeArea.swift
+++ b/Demo_MondrianLayout/Book.SafeArea.swift
@@ -7,7 +7,7 @@ var _book_SafeArea: BookView {
 
     BookPush(title: "Push") {
       AnyViewController { view in
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           LayoutContainer(attachedSafeAreaEdges: .vertical) {
             VStackBlock {
               UIView.mock(
@@ -32,7 +32,7 @@ var _book_SafeArea: BookView {
     BookPush(title: "Push custom") {
       AnyViewController { view in
 
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           LayoutContainer(top: .view(.top), leading: .view(.leading), bottom: .safeArea(.top), trailing: .view(.trailing)) {
             UIView.mock(
               backgroundColor: .layeringColor,
@@ -43,7 +43,7 @@ var _book_SafeArea: BookView {
 
         }
 
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           LayoutContainer(attachedSafeAreaEdges: .vertical) {
             UIView.mock(
               backgroundColor: .layeringColor,
@@ -58,7 +58,7 @@ var _book_SafeArea: BookView {
 
     BookPush(title: "Push") {
       AnyViewController { view in
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           LayoutContainer(attachedSafeAreaEdges: .vertical) {
             ZStackBlock {
               UIView.mock(
@@ -77,7 +77,7 @@ var _book_SafeArea: BookView {
 
     BookPush(title: "Bottom Buttons") {
       AnyViewController { view in
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           LayoutContainer(attachedSafeAreaEdges: .vertical) {
             ZStackBlock {
 

--- a/Demo_MondrianLayout/Book.Sizing.swift
+++ b/Demo_MondrianLayout/Book.Sizing.swift
@@ -8,7 +8,7 @@ var _book_sizing: BookView {
 
     BookPreview {
       ExampleView(width: 200, height: 200) { (view: UIView) in
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           ZStackBlock {
 
             HStackBlock {

--- a/Demo_MondrianLayout/Book.VGridBlock.swift
+++ b/Demo_MondrianLayout/Book.VGridBlock.swift
@@ -8,7 +8,7 @@ var _book_VGridConstraint: BookView {
 
     BookPreview {
       ExampleView(width: 100, height: nil) { view in
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           VGridBlock(
             columns: [
               .init(.flexible(), spacing: 16),

--- a/Demo_MondrianLayout/Book.VStackBlock.swift
+++ b/Demo_MondrianLayout/Book.VStackBlock.swift
@@ -8,7 +8,7 @@ var _book_VStackBlock: BookView {
 
     BookPreview {
       ExampleView(width: 200, height: 200) { (view: UIView) in
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           VStackBlock(alignment: .leading) {
             UILabel.mockMultiline(text: BookGenerator.loremIpsum(length: 10))
               .viewBlock
@@ -25,7 +25,7 @@ var _book_VStackBlock: BookView {
 
     BookPreview {
       ExampleView(width: nil, height: 180) { (view: UIView) in
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           VStackBlock(spacing: 4) {
             UIView.mock(
               backgroundColor: .mondrianYellow,
@@ -55,7 +55,7 @@ var _book_VStackBlock: BookView {
     BookForEach(data: [.center, .leading, .trailing, .fill] as [VStackBlock.XAxisAlignment]) { alignment in
       BookPreview {
         ExampleView(width: nil, height: nil) { (view: UIView) in
-          view.mondrian.buildSubviews {
+          Mondrian.buildSubviews(on: view) {
             VStackBlock(spacing: 4, alignment: alignment) {
               UILabel.mockMultiline(text: "Hello", textColor: .white)
                 .viewBlock
@@ -78,7 +78,7 @@ var _book_VStackBlock: BookView {
 
     BookPreview {
       ExampleView(width: nil, height: nil) { (view: UIView) in
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           VStackBlock(spacing: 4) {
             UIView.mock(
               backgroundColor: .mondrianYellow,
@@ -102,7 +102,7 @@ var _book_VStackBlock: BookView {
 
     BookPreview {
       ExampleView(width: nil, height: nil) { (view: UIView) in
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           VStackBlock(spacing: 4) {
             UIView.mock(
               backgroundColor: .mondrianYellow,
@@ -132,7 +132,7 @@ var _book_VStackBlock: BookView {
         let boxes = (0..<3).map { _ in UIView.mock(backgroundColor: .layeringColor) }
         let guides = (0..<2).map { _ in UILayoutGuide() }
 
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           VStackBlock(alignment: .leading) {
 
             boxes[0]

--- a/Demo_MondrianLayout/Book.ViewController.swift
+++ b/Demo_MondrianLayout/Book.ViewController.swift
@@ -9,7 +9,7 @@ var _book_ViewController: BookView {
     BookPush(title: "Push") {
 
       let body = ExampleView(width: nil, height: nil) { view in
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           HStackBlock {
             UIView.mock(
               backgroundColor: .layeringColor,
@@ -28,7 +28,7 @@ var _book_ViewController: BookView {
       }
 
       let container = ExampleView(width: nil, height: nil) { view in
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           ZStackBlock {
             body.viewBlock.padding(10)
           }
@@ -36,7 +36,7 @@ var _book_ViewController: BookView {
       }
 
       return AnyViewController { view in
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           LayoutContainer(attachedSafeAreaEdges: .all) {
             ZStackBlock {
               container

--- a/Demo_MondrianLayout/Book.ZStackBlock.swift
+++ b/Demo_MondrianLayout/Book.ZStackBlock.swift
@@ -7,7 +7,7 @@ var _book_ZStackConstraint: BookView {
 
     BookPreview {
       ExampleView(width: 100, height: 100) { view in
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           ZStackBlock {
             ZStackBlock {
               UILabel.mockSingleline(text: "Hello Hello Hello")
@@ -24,7 +24,7 @@ var _book_ZStackConstraint: BookView {
 
     BookPreview {
       ExampleView(width: 100, height: 100) { view in
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           LayoutContainer(attachedSafeAreaEdges: .vertical) {
             ZStackBlock {
 
@@ -158,7 +158,7 @@ var _book_ZStackConstraint: BookView {
     )
     BookPreview {
       ExampleView(width: 100, height: 100) { view in
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           LayoutContainer(attachedSafeAreaEdges: .vertical) {
             ZStackBlock {
               UIView.mock(
@@ -178,7 +178,7 @@ var _book_ZStackConstraint: BookView {
     BookParagraph("The view has intrinsicContentSize but expanded by relative modifier")
     BookPreview {
       ExampleView(width: 100, height: 100) { view in
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           LayoutContainer(attachedSafeAreaEdges: .vertical) {
             ZStackBlock {
               UIView.mock(
@@ -195,7 +195,7 @@ var _book_ZStackConstraint: BookView {
 
     BookPreview {
       ExampleView(width: nil, height: nil) { (view: UIView) in
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           VStackBlock {
             ZStackBlock {
               UIView.mock(
@@ -218,7 +218,7 @@ var _book_ZStackConstraint: BookView {
 
     BookPreview {
       ExampleView(width: nil, height: nil) { (view: UIView) in
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           VStackBlock {
             UIView.mock(
               backgroundColor: .mondrianYellow,
@@ -259,7 +259,7 @@ var _book_ZStackConstraint: BookView {
 
     BookPreview {
       ExampleView(width: nil, height: nil) { (view: UIView) in
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           VStackBlock {
             UIView.mock(
               backgroundColor: .mondrianYellow,
@@ -280,7 +280,7 @@ var _book_ZStackConstraint: BookView {
 
     BookPreview {
       ExampleView(width: nil, height: nil) { (view: UIView) in
-        view.mondrian.buildSubviews {
+        Mondrian.buildSubviews(on: view) {
           ZStackBlock {
 
             UIView.mock(

--- a/Demo_MondrianLayout/InstagramPostView.swift
+++ b/Demo_MondrianLayout/InstagramPostView.swift
@@ -44,7 +44,7 @@ final class InstagramPostView: UIView {
       $0.width(200)
     }
 
-    self.mondrian.buildSubviews {
+    Mondrian.buildSubviews(on: self) {
       VStackBlock(alignment: .fill) {
 
         HStackBlock {

--- a/MondrianLayout.xcodeproj/project.pbxproj
+++ b/MondrianLayout.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		4BACE5DD276912CD00C32A09 /* VGridTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BACE5DC276912CD00C32A09 /* VGridTests.swift */; };
 		4BAD3679268386FA00788518 /* MondrianNamespace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BAD3678268386FA00788518 /* MondrianNamespace.swift */; };
 		4BB75A29269035F400EA4F54 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB75A28269035F400EA4F54 /* Utils.swift */; };
+		4BBD72022769D47A00F1FFAF /* EntryPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BBD72012769D47A00F1FFAF /* EntryPoint.swift */; };
 		4BBFF31726EC7DFF00FCC451 /* Book.Sizing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BBFF31626EC7DFF00FCC451 /* Book.Sizing.swift */; };
 		4BBFF31926EC82D300FCC451 /* SizingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BBFF31826EC82D300FCC451 /* SizingTests.swift */; };
 		4BC4752126E7598B000C8492 /* ClassicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC4752026E7598B000C8492 /* ClassicTests.swift */; };
@@ -183,6 +184,7 @@
 		4BACE5DC276912CD00C32A09 /* VGridTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGridTests.swift; sourceTree = "<group>"; };
 		4BAD3678268386FA00788518 /* MondrianNamespace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MondrianNamespace.swift; sourceTree = "<group>"; };
 		4BB75A28269035F400EA4F54 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
+		4BBD72012769D47A00F1FFAF /* EntryPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryPoint.swift; sourceTree = "<group>"; };
 		4BBFF31626EC7DFF00FCC451 /* Book.Sizing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Book.Sizing.swift; sourceTree = "<group>"; };
 		4BBFF31826EC82D300FCC451 /* SizingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SizingTests.swift; sourceTree = "<group>"; };
 		4BC4752026E7598B000C8492 /* ClassicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClassicTests.swift; sourceTree = "<group>"; };
@@ -268,6 +270,7 @@
 		4B4057642675C501003B28A1 /* MondrianLayout */ = {
 			isa = PBXGroup;
 			children = (
+				4BBD72012769D47A00F1FFAF /* EntryPoint.swift */,
 				4B3B0F70274E8F8D001C9E6B /* Manager */,
 				4B9B07EE267E1C2900818A40 /* Classic */,
 				4BFF75CF2677CC16003FA7F0 /* Descriptors */,
@@ -566,6 +569,7 @@
 				4B47F6412678E51200BDE2DB /* Edge.swift in Sources */,
 				4B9E1A1426762D6A00D1E1C9 /* ViewBlock.swift in Sources */,
 				4BACE5D72768EFB700C32A09 /* VGridBlock.swift in Sources */,
+				4BBD72022769D47A00F1FFAF /* EntryPoint.swift in Sources */,
 				4B384D8A2675CDA9001B0267 /* LayoutBuilderContext.swift in Sources */,
 				4B73820C267A0D6900D77986 /* _LayoutBlockNode.swift in Sources */,
 				4B9E1A1C2676333C00D1E1C9 /* _LayoutBlockType.swift in Sources */,

--- a/MondrianLayout/Classic/LayoutDescriptor.swift
+++ b/MondrianLayout/Classic/LayoutDescriptor.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-@available(*, deprecated, message: "Use Mondrian.layout")
+@available(*, deprecated, renamed: "Mondrian.layout")
 @discardableResult
 public func mondrianBatchLayout(
   @MondrianArrayBuilder<LayoutDescriptor> _ closure: () -> [LayoutDescriptor]

--- a/MondrianLayout/Classic/LayoutDescriptor.swift
+++ b/MondrianLayout/Classic/LayoutDescriptor.swift
@@ -1,21 +1,11 @@
 import UIKit
 
+@available(*, deprecated, message: "Use Mondrian.layout")
 @discardableResult
 public func mondrianBatchLayout(
   @MondrianArrayBuilder<LayoutDescriptor> _ closure: () -> [LayoutDescriptor]
 ) -> ConstraintGroup {
-
-  let descriptors = closure()
-
-  let group = ConstraintGroup(constraints: [])
-
-  descriptors.forEach {
-    let g = $0.activate()
-    group.append(g)
-  }
-
-  return group
-
+  Mondrian.layout(closure)
 }
 
 /**
@@ -703,46 +693,4 @@ extension NSLayoutYAxisAnchor {
     }
 
   }
-}
-
-extension MondrianNamespace where Base: UIView {
-
-  /**
-   Entry point to describe layout constraints
-   Activates by calling `activate()` or using `mondrianBatchLayout`
-
-   ```swift
-   view.mondrian.layout
-     .top(.toSuperview)
-     .left(.toSuperview)
-     .right(.to(box2).left)
-     .bottom(.to(box2).bottom)
-     .activate()
-   ```
-   */
-  public var layout: LayoutDescriptor {
-    .init(view: base)
-  }
-
-}
-
-extension MondrianNamespace where Base: UILayoutGuide {
-
-  /**
-   Entry point to describe layout constraints
-   Activates by calling `activate()` or using `mondrianBatchLayout`
-
-   ```swift
-   view.mondrian.layout
-     .top(.toSuperview)
-     .left(.toSuperview)
-     .right(.to(box2).left)
-     .bottom(.to(box2).bottom)
-     .activate()
-   ```
-   */
-  public var layout: LayoutDescriptor {
-    .init(layoutGuide: base)
-  }
-
 }

--- a/MondrianLayout/EntryPoint.swift
+++ b/MondrianLayout/EntryPoint.swift
@@ -1,0 +1,80 @@
+import UIKit
+
+public enum Mondrian {
+
+  @discardableResult
+  public static func layout(@MondrianArrayBuilder<LayoutDescriptor> _ closure: () -> [LayoutDescriptor]
+  ) -> ConstraintGroup {
+
+    let descriptors = closure()
+
+    let group = ConstraintGroup(constraints: [])
+
+    descriptors.forEach {
+      let g = $0.activate()
+      group.append(g)
+    }
+
+    return group
+
+  }
+
+  /**
+   Builds subviews of this view.
+   - activating layout-constraints
+   - adding layout-guides
+   - applying content-hugging, content-compression-resistance
+
+   You can start to describe like followings:
+
+   ```swift
+   Mondrian.buildSubviews(on: view) {
+     ZStackBlock {
+       ...
+     }
+   }
+   ```
+
+   ```swift
+   Mondrian.buildSubviews(on: view) {
+     LayoutContainer(attachedSafeAreaEdges: .vertical) {
+       ...
+     }
+   }
+   ```
+
+
+   ```swift
+   Mondrian.buildSubviews(on: view) {
+     LayoutContainer(attachedSafeAreaEdges: .vertical) {
+       ...
+     }
+     ZStackBlock {
+       ...
+     }
+   }
+   ```
+   */
+  @discardableResult
+  public static func buildSubviews(on view: UIView, @EntrypointBuilder _ build: () -> [EntrypointBuilder.Either]) -> LayoutBuilderContext {
+
+    let entrypoints = build()
+
+    let context = LayoutBuilderContext(targetView: view)
+
+    for entrypoint in entrypoints {
+      switch entrypoint {
+      case .block(let block):
+        block.setupConstraints(parent: .init(view: view), in: context)
+      case .container(let container):
+        container.setupConstraints(parent: view, in: context)
+      }
+    }
+
+    context.prepareViewHierarchy()
+    context.activate()
+
+    return context
+  }
+
+}

--- a/MondrianLayout/Extensions/UIView+Mondrian.swift
+++ b/MondrianLayout/Extensions/UIView+Mondrian.swift
@@ -36,64 +36,13 @@ public enum EntrypointBuilder {
 
 extension MondrianNamespace where Base : UIView {
 
-  /**
-   Builds subviews of this view.
-   - activating layout-constraints
-   - adding layout-guides
-   - applying content-hugging, content-compression-resistance
-
-   You can start to describe like followings:
-
-   ```swift
-   view.mondrian.buildSubviews {
-     ZStackBlock {
-       ...
-     }
-   }
-   ```
-
-   ```swift
-   view.mondrian.buildSubviews {
-     LayoutContainer(attachedSafeAreaEdges: .vertical) {
-       ...
-     }
-   }
-   ```
-
-
-   ```swift
-   view.mondrian.buildSubviews {
-     LayoutContainer(attachedSafeAreaEdges: .vertical) {
-       ...
-     }
-     ZStackBlock {
-       ...
-     }
-   }
-   ```
-   */
+  @available(*, deprecated, message: "Use Mondrian.buildSubviews")
   @discardableResult
   public func buildSubviews(@EntrypointBuilder _ build: () -> [EntrypointBuilder.Either]) -> LayoutBuilderContext {
-
-    let entrypoints = build()
-
-    let context = LayoutBuilderContext(targetView: base)
-
-    for entrypoint in entrypoints {
-      switch entrypoint {
-      case .block(let block):
-        block.setupConstraints(parent: .init(view: base), in: context)
-      case .container(let container):
-        container.setupConstraints(parent: base, in: context)
-      }
-    }
-
-    context.prepareViewHierarchy()
-    context.activate()
-
-    return context
+    Mondrian.buildSubviews(on: base, build)
   }
 
+  @available(*, deprecated, message: "Use classic layout")
   /// Applies the layout of the dimension in itself.
   public func buildSelfSizing(build: (ViewBlock) -> ViewBlock) {
 

--- a/MondrianLayout/LayoutBlocks/ZStackBlock.swift
+++ b/MondrianLayout/LayoutBlocks/ZStackBlock.swift
@@ -8,7 +8,7 @@ import UIKit
 /// **Put a view snapping to edge**
 ///
 /// ```swift
-/// self.mondrian.buildSubviews {
+/// Mondrian.buildSubviews(on: self) {
 ///   ZStackBlock {
 ///     backgroundView.viewBlock.relative(0)
 ///   }

--- a/MondrianLayout/MondrianNamespace.swift
+++ b/MondrianLayout/MondrianNamespace.swift
@@ -9,3 +9,52 @@ public struct MondrianNamespace<Base> {
   }
 }
 
+extension MondrianNamespace where Base: UIView {
+
+  /**
+   Entry point to describe layout constraints
+   Activates by calling `activate()` or using `mondrianBatchLayout`
+
+   ```swift
+   view.mondrian.layout
+   .top(.toSuperview)
+   .left(.toSuperview)
+   .right(.to(box2).left)
+   .bottom(.to(box2).bottom)
+   .activate()
+   ```
+   */
+  public var layout: LayoutDescriptor {
+    .init(view: base)
+  }
+//
+//  public var block: ViewBlock {
+//    .init(base)
+//  }
+
+}
+
+extension MondrianNamespace where Base: UILayoutGuide {
+
+  /**
+   Entry point to describe layout constraints
+   Activates by calling `activate()` or using `mondrianBatchLayout`
+
+   ```swift
+   view.mondrian.layout
+   .top(.toSuperview)
+   .left(.toSuperview)
+   .right(.to(box2).left)
+   .bottom(.to(box2).bottom)
+   .activate()
+   ```
+   */
+  public var layout: LayoutDescriptor {
+    .init(layoutGuide: base)
+  }
+//
+//  public var block: LayoutGuideBlock {
+//    .init(base)
+//  }
+
+}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 🏗 **Structured Layout API**
 
 ```swift
-view.mondrian.buildSubviews {
+Mondrian.buildSubviews(on: view) {
   VStackBlock {
   
     titleLabel
@@ -236,7 +236,7 @@ class MyView: UIView {
     super.init(frame: .zero)
     
     // Seting up constraints constraints, layoutGuides and adding subviews
-    mondrian.buildSubviews {
+    Mondrian.buildSubviews(on: self) {
       VStackBlock {
         nameLabel
         detailLabel
@@ -244,8 +244,8 @@ class MyView: UIView {
     }
     
     // Seting up constraints for the view itself.
-    mondrian.buildSelfSizing {
-      $0.width(200).maxHeight(...)... // can be method cain.
+    Mondrian.layout {
+      self.mondrian.layout.width(200) // can be method cain.
     }
     
   }
@@ -262,7 +262,7 @@ You can replace it with `UIViewController.view`.
 Attaching to top and bottom safe-area.
 
 ```swift
-self.mondrian.buildSubviews {
+Mondrian.buildSubviews(on: self) {
   LayoutContainer(attachedSafeAreaEdges: .vertical) {
     VStackBlock {
       ...
@@ -274,7 +274,7 @@ self.mondrian.buildSubviews {
 #### Put a view snapping to edge
 
 ```swift
-self.mondrian.buildSubviews {
+Mondrian.buildSubviews(on: self) {
   ZStackBlock {
     backgroundView.viewBlock.relative(0)    
   }
@@ -298,18 +298,21 @@ ZStackBlock {
 #### Add constraints to view itself
 
 ```swift
-self.mondrian.buildSelfSizing {
-  $0.width(...)
-    .height(...)          
+Mondrian.layout {
+  self.mondrian.layout.width(...).height(...)
 }
 ```
 
+or
+```swift
+self.mondrian.layout.width(...).height(...).activate()
+```
 #### Stacking views on Z axis
 
 `relative(0)` fills to the edges of `ZStackBlock`.
 
 ```swift
-self.mondrian.buildSubviews {
+Mondrian.buildSubviews(on: self) {
   ZStackBlock {
     profileImageView.viewBlock.relative(0)
     textOverlayView.viewBlock.relative(0)
@@ -353,7 +356,7 @@ Alignment
 |<img width="358" alt="CleanShot 2021-06-17 at 00 09 43@2x" src="https://user-images.githubusercontent.com/1888355/122245037-5486c480-cf00-11eb-872a-e98cfce7262e.png">|<img width="359" alt="CleanShot 2021-06-17 at 00 09 51@2x" src="https://user-images.githubusercontent.com/1888355/122245054-58b2e200-cf00-11eb-9691-607a75060f75.png">|<img width="362" alt="CleanShot 2021-06-17 at 00 09 59@2x" src="https://user-images.githubusercontent.com/1888355/122245073-5d779600-cf00-11eb-856d-0e48712377d7.png">|<img width="355" alt="CleanShot 2021-06-17 at 00 10 06@2x" src="https://user-images.githubusercontent.com/1888355/122245096-62d4e080-cf00-11eb-99f2-2969a3ccc350.png">|
 
 ```swift
-self.mondrian.buildSubviews {
+Mondrian.buildSubviews(on: self) {
   VStackBlock(spacing: 4, alignment: alignment) {
     UILabel.mockMultiline(text: "Hello", textColor: .white)
       .viewBlock
@@ -500,7 +503,7 @@ Batch layout**
 
 ```swift
 // returns `ConstraintGroup`
-mondrianBatchLayout {
+Mondrian.layout {
 
   box1.mondrian.layout
     .top(.toSuperview)

--- a/Tests/HStackTests.swift
+++ b/Tests/HStackTests.swift
@@ -15,7 +15,7 @@ final class HStackTests: XCTestCase {
   func test_mixing_spacer() {
 
     let view = ExampleView(width: 180, height: nil) { (view: UIView) in
-      view.mondrian.buildSubviews {
+      Mondrian.buildSubviews(on: view) {
         HStackBlock(spacing: 4) {
           UIView.mock(
             backgroundColor: .layeringColor,
@@ -47,7 +47,7 @@ final class HStackTests: XCTestCase {
   func test_additional_spacing() {
 
     let view = ExampleView(width: nil, height: nil) { (view: UIView) in
-      view.mondrian.buildSubviews {
+      Mondrian.buildSubviews(on: view) {
         HStackBlock(spacing: 4) {
           UIView.mock(
             preferredSize: .smallSquare

--- a/Tests/OverlayTests.swift
+++ b/Tests/OverlayTests.swift
@@ -9,7 +9,7 @@ final class OverlayTests: XCTestCase {
   func test_1() {
 
     let view = ExampleView(width: nil, height: nil) { (view: UIView) in
-      view.mondrian.buildSubviews {
+      Mondrian.buildSubviews(on: view) {
         UIView.mock(
           backgroundColor: .layeringColor,
           preferredSize: .init(width: 100, height: 100)
@@ -35,7 +35,7 @@ final class OverlayTests: XCTestCase {
   func test_2() {
 
     let view = ExampleView(width: nil, height: nil) { (view: UIView) in
-      view.mondrian.buildSubviews {
+      Mondrian.buildSubviews(on: view) {
         VStackBlock {
           UIView.mock(
             preferredSize: .smallSquare

--- a/Tests/RelativeTests.swift
+++ b/Tests/RelativeTests.swift
@@ -7,7 +7,7 @@ final class RelateiveTests: XCTestCase {
 
   func test_centering_in_ambiguous() {
     let view = ExampleView(width: 100, height: 100) { view in
-      view.mondrian.buildSubviews {
+      Mondrian.buildSubviews(on: view) {
         ZStackBlock {
           UILabel.mockSingleline(text: "A")
             .viewBlock
@@ -22,7 +22,7 @@ final class RelateiveTests: XCTestCase {
 
   func test_accumulate_relative() {
     let view = ExampleView(width: 100, height: 100) { view in
-      view.mondrian.buildSubviews {
+      Mondrian.buildSubviews(on: view) {
         LayoutContainer(attachedSafeAreaEdges: .all) {
           ZStackBlock {
 
@@ -44,7 +44,7 @@ final class RelateiveTests: XCTestCase {
   func test_accumulate_padding() {
 
     let view = ExampleView(width: 100, height: 100) { view in
-      view.mondrian.buildSubviews {
+      Mondrian.buildSubviews(on: view) {
         LayoutContainer(attachedSafeAreaEdges: .vertical) {
           VStackBlock {
             UIView.mock(

--- a/Tests/SizingTests.swift
+++ b/Tests/SizingTests.swift
@@ -7,7 +7,7 @@ final class SizingTests: XCTestCase {
 
   func test_sizing() {
     let view =  ExampleView(width: 200, height: 200) { (view: UIView) in
-      view.mondrian.buildSubviews {
+      Mondrian.buildSubviews(on: view) {
         ZStackBlock {
 
           HStackBlock {

--- a/Tests/SyntaxTests.swift
+++ b/Tests/SyntaxTests.swift
@@ -15,7 +15,7 @@ final class SyntaxTests: XCTestCase {
   func test_vStack() {
 
     let view = ExampleView(width: 20, height: nil) { view in
-      view.mondrian.buildSubviews {
+      Mondrian.buildSubviews(on: view) {
         LayoutContainer(attachedSafeAreaEdges: .vertical) {
           VStackBlock {
 
@@ -51,7 +51,7 @@ final class SyntaxTests: XCTestCase {
   func test_hStack() {
 
     let view = ExampleView(width: nil, height: 20) { view in
-      view.mondrian.buildSubviews {
+      Mondrian.buildSubviews(on: view) {
         LayoutContainer(attachedSafeAreaEdges: .vertical) {
           HStackBlock {
 

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -16,7 +16,7 @@ final class LayoutSnapshotTests: XCTestCase {
   func test_1() {
 
     let view = ExampleView(width: 100, height: 100) { view in
-      view.mondrian.buildSubviews {
+      Mondrian.buildSubviews(on: view) {
         VStackBlock {
           ZStackBlock {
             UIView.mock(
@@ -43,7 +43,7 @@ final class LayoutSnapshotTests: XCTestCase {
   func test_mondrian() {
 
     let view = ExampleView(width: 200, height: 200) { (view: UIView) in
-      view.mondrian.buildSubviews {
+      Mondrian.buildSubviews(on: view) {
 
         HStackBlock(spacing: 2, alignment: .fill) {
           VStackBlock(spacing: 2, alignment: .fill) {

--- a/Tests/VGridTests.swift
+++ b/Tests/VGridTests.swift
@@ -15,7 +15,7 @@ final class VGridTests: XCTestCase {
   func test_basic() {
 
     let view = ExampleView(width: 100, height: nil) { view in
-      view.mondrian.buildSubviews {
+      Mondrian.buildSubviews(on: view) {
         VGridBlock(
           columns: [
             .init(.flexible(), spacing: 16),

--- a/Tests/VStackTests.swift
+++ b/Tests/VStackTests.swift
@@ -14,7 +14,7 @@ final class VStackTests: XCTestCase {
 
   func test_mixing_spacer() {
     let view = ExampleView(width: nil, height: 180) { (view: UIView) in
-      view.mondrian.buildSubviews {
+      Mondrian.buildSubviews(on: view) {
         VStackBlock(spacing: 4) {
           UIView.mock(
             backgroundColor: .layeringColor,
@@ -45,7 +45,7 @@ final class VStackTests: XCTestCase {
   func test_enter() {
 
     let view = ExampleView(width: nil, height: nil) { (view: UIView) in
-      view.mondrian.buildSubviews {
+      Mondrian.buildSubviews(on: view) {
         VStackBlock(spacing: 4, alignment: .center) {
           UILabel.mockMultiline(text: "Hello", textColor: .white)
             .viewBlock
@@ -70,7 +70,7 @@ final class VStackTests: XCTestCase {
   func test_leading() {
 
     let view = ExampleView(width: nil, height: nil) { (view: UIView) in
-      view.mondrian.buildSubviews {
+      Mondrian.buildSubviews(on: view) {
         VStackBlock(spacing: 4, alignment: .leading) {
           UILabel.mockMultiline(text: "Hello", textColor: .white)
             .viewBlock
@@ -95,7 +95,7 @@ final class VStackTests: XCTestCase {
   func test_trailing() {
 
     let view = ExampleView(width: nil, height: nil) { (view: UIView) in
-      view.mondrian.buildSubviews {
+      Mondrian.buildSubviews(on: view) {
         VStackBlock(spacing: 4, alignment: .trailing) {
           UILabel.mockMultiline(text: "Hello", textColor: .white)
             .viewBlock
@@ -120,7 +120,7 @@ final class VStackTests: XCTestCase {
   func test_additional_spacing() {
 
     let view = ExampleView(width: nil, height: nil) { (view: UIView) in
-      view.mondrian.buildSubviews {
+      Mondrian.buildSubviews(on: view) {
         VStackBlock(spacing: 4) {
           UIView.mock(
             preferredSize: .smallSquare
@@ -145,7 +145,7 @@ final class VStackTests: XCTestCase {
   func test_label_alignment() {
 
     let view = ExampleView(width: 200, height: 200) { (view: UIView) in
-      view.mondrian.buildSubviews {
+      Mondrian.buildSubviews(on: view) {
         VStackBlock(alignment: .leading) {
           UILabel.mockMultiline(text: "Hello")
             .viewBlock
@@ -169,7 +169,7 @@ final class VStackTests: XCTestCase {
       let boxes = (0..<3).map { _ in UIView.mock(backgroundColor: .layeringColor) }
       let guides = (0..<2).map { _ in UILayoutGuide() }
 
-      view.mondrian.buildSubviews {
+      Mondrian.buildSubviews(on: view) {
         VStackBlock(alignment: .leading) {
 
           boxes[0]

--- a/Tests/ZStackTests.swift
+++ b/Tests/ZStackTests.swift
@@ -15,7 +15,7 @@ final class ZStackTests: XCTestCase {
   func test_minimum_padding() {
 
     let view = ExampleView(width: 100, height: 100) { view in
-      view.mondrian.buildSubviews {
+      Mondrian.buildSubviews(on: view) {
         ZStackBlock {
           ZStackBlock {
             UILabel.mockSingleline(text: "Hello Hello Hello")
@@ -35,7 +35,7 @@ final class ZStackTests: XCTestCase {
   func test_expandsElementIfCanBeExpanding() {
 
     let view = ExampleView(width: 100, height: 100) { view in
-      view.mondrian.buildSubviews {
+      Mondrian.buildSubviews(on: view) {
         LayoutContainer(attachedSafeAreaEdges: .vertical) {
           ZStackBlock {
 
@@ -61,7 +61,7 @@ final class ZStackTests: XCTestCase {
   func test_expandsElementWithRelative() {
 
     let view = ExampleView(width: 100, height: 100) { view in
-      view.mondrian.buildSubviews {
+      Mondrian.buildSubviews(on: view) {
         LayoutContainer(attachedSafeAreaEdges: .vertical) {
           ZStackBlock {
             UIView.mock(
@@ -81,7 +81,7 @@ final class ZStackTests: XCTestCase {
   func test_alignSelf() {
 
     let view = ExampleView(width: 100, height: 100) { view in
-      view.mondrian.buildSubviews {
+      Mondrian.buildSubviews(on: view) {
         LayoutContainer(attachedSafeAreaEdges: .vertical) {
           ZStackBlock {
 


### PR DESCRIPTION
Renames two methods of laying out in favor of this proposal.
https://github.com/muukii/MondrianLayout/issues/71

`view.mondrian.buildSubviews {` -> `Mondrian.buildSubviews(on: view) {`
`mondrianBatchLayout {` -> `Mondrian.layout {`

`s/([^ ]+).mondrian.buildSubviews \{/Mondrian.buildSubviews(on: $1) {`